### PR TITLE
Fix server not replicating to clients on join (temp fix)

### DIFF
--- a/src/shared/Shatterbox/Main.luau
+++ b/src/shared/Shatterbox/Main.luau
@@ -1526,6 +1526,9 @@ end
 
 
 local function ReplicateMapFromServer(SerialOpDirties, mapParts)
+	if clientMapFolder then
+		clientMapFolder:ClearAllChildren()
+	end
 
 	for _, serialOpDirty in ipairs(SerialOpDirties) do
 		local dirtied = {}
@@ -1533,14 +1536,14 @@ local function ReplicateMapFromServer(SerialOpDirties, mapParts)
 		local ID = serialOpDirty.ID
 
 		for _, serialDirtied in ipairs(serialOpDirty.Dirties) do
-
 			local replicatedOriginal = PartFromTemplate(serialDirtied)
 			replicatedOriginal.CFrame = serialDirtied.OriginalPart.CFrame
 			replicatedOriginal.Size = serialDirtied.OriginalPart.Size
 
 			local model = Instance.new("Model")
+			model.Name = replicatedOriginal.Name
 			model:AddTag("ShatterboxInstance")
-			model:SetAttribute("GridSize", serialDirtied.Attributes.GridSize)
+			model:SetAttribute("GridSize", serialDirtied.GridSize or serialDirtied.Attributes and serialDirtied.Attributes.GridSize)
 			for _, tag in ipairs(serialDirtied.Tags) do
 				model:AddTag(tag)
 			end
@@ -1552,8 +1555,10 @@ local function ReplicateMapFromServer(SerialOpDirties, mapParts)
 				Part.Parent = model
 			end
 
+			replicatedOriginal.Parent = model
+
 			if Settings.UseGreedyMeshing then
-				FlagDirty(ID, serialDirtied.GridSize, model)
+				FlagDirty(ID, serialDirtied.GridSize or serialDirtied.Attributes and serialDirtied.Attributes.GridSize, model)
 			end
 
 			model.Parent = clientMapFolder


### PR DESCRIPTION
server isn't properly replicating current destruction state (clients just seeing the map as if it never existed). possibly due to server only replicating instances in dirty state but is not reconstructing the part/model fragments of an ongoing destruction. incomplete data? also not being parented (possibly main reason why lol)

what i did (___temporary___ fix): simply I just reset the client state (cleaned client folder and put parts back in their original models). the parts (walls) reset, and the voxels clean up after the given time (in puppeteering state, they will be anchored... which is what i tested). also attempted to fill in the missing data.

idk how fix fragment state replicating  so I just reset it 